### PR TITLE
✨feature: show Interface-MAC on UI and OpenCommunication return-value

### DIFF
--- a/CSK_Module_Fieldbus/project.mf.xml
+++ b/CSK_Module_Fieldbus/project.mf.xml
@@ -341,6 +341,7 @@ NAME will be replaced by data identifier (e.g. 'CSK_Fieldbus.OnNewData_Data1').<
                 </function>
                 <function name="openCommunication">
                     <desc>Function to open fieldbus communication.</desc>
+                    <return desc="" multiplicity="?" name="success" type="bool"/>
                 </function>
                 <function name="closeCommunication">
                     <desc>Function to close fieldbus communication.</desc>

--- a/CSK_Module_Fieldbus/project.mf.xml
+++ b/CSK_Module_Fieldbus/project.mf.xml
@@ -341,7 +341,7 @@ NAME will be replaced by data identifier (e.g. 'CSK_Fieldbus.OnNewData_Data1').<
                 </function>
                 <function name="openCommunication">
                     <desc>Function to open fieldbus communication.</desc>
-                    <return desc="" multiplicity="?" name="success" type="bool"/>
+                    <return desc="TRUE if communication is opened successfully otherwise FALSE" multiplicity="1" name="success" type="bool"/>
                 </function>
                 <function name="closeCommunication">
                     <desc>Function to close fieldbus communication.</desc>

--- a/CSK_Module_Fieldbus/scripts/Communication/Fieldbus/Fieldbus_Controller.lua
+++ b/CSK_Module_Fieldbus/scripts/Communication/Fieldbus/Fieldbus_Controller.lua
@@ -333,12 +333,14 @@ end
 Script.serveFunction('CSK_Fieldbus.setTransmissionMode', setTransmissionMode)
 
 local function openCommunication()
+  local success = false
   if fieldbus_Model.currentStatus == 'CLOSED' then
     _G.logger:info(nameOfModule .. ": Open communciation.")
-    fieldbus_Model.openCommunication()
+    success = fieldbus_Model.openCommunication()
   else
     _G.logger:fine("Connection already active.")
   end
+  return success 
 end
 Script.serveFunction('CSK_Fieldbus.openCommunication', openCommunication)
 

--- a/CSK_Module_Fieldbus/scripts/Communication/Fieldbus/Fieldbus_Model.lua
+++ b/CSK_Module_Fieldbus/scripts/Communication/Fieldbus/Fieldbus_Model.lua
@@ -396,7 +396,7 @@ local function getProfinetIOConfigInfo()
   fieldbus_Model.parameters.profinetIO.deviceName = FieldBus.Config.ProfinetIO.getDeviceName()
   fieldbus_Model.parameters.profinetIO.ipAddress, fieldbus_Model.parameters.profinetIO.subnetMask, fieldbus_Model.parameters.profinetIO.gateway, fieldbus_Model.parameters.profinetIO.remanent = FieldBus.Config.ProfinetIO.getInterfaceConfig()
 
-  local macAddress = FieldBus.Config.ProfinetIO.getMACAddress(fieldbus_Model.port)
+  local macAddress = FieldBus.Config.ProfinetIO.getMACAddress('INTERFACE')
   if macAddress then
     fieldbus_Model.parameters.profinetIO.macAddress = macAddress
   else
@@ -619,15 +619,18 @@ fieldbus_Model.setTransmissionMode = setTransmissionMode
 
 --- Function to open fieldbus communication
 local function openCommunication()
+  local success = false
   create()
   fieldbus_Model.parameters.active = true
   if fieldbus_Model.handle then
     if fieldbus_Model.parameters.createMode == 'EXPLICIT_OPEN' then
       fieldbus_Model.handle:open()
     end
+    success = true
   else
     _G.logger:warning("Not able to open fieldbus communication.")
   end
+  return success
 end
 fieldbus_Model.openCommunication = openCommunication
 
@@ -668,8 +671,8 @@ local function transmit(data)
   if fieldbus_Model.handle then
     local numberOfBytes = fieldbus_Model.handle:transmit(data)
     if numberOfBytes ~= 0 then
-      _G.logger:fine("Send " .. tostring(numberOfBytes) .. "data Bytes.")
-      Script.notifyEvent('Fieldbus_OnNewStatusLogMessage', "Send " .. tostring(numberOfBytes) .. "data Bytes.")
+      _G.logger:fine("Send " .. tostring(numberOfBytes) .. " data Bytes.")
+      Script.notifyEvent('Fieldbus_OnNewStatusLogMessage', "Send " .. tostring(numberOfBytes) .. " data Bytes.")
     else
       _G.logger:warning("Transmit error.")
       Script.notifyEvent('Fieldbus_OnNewStatusLogMessage', "Transmit error.")

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Tested on:
 |Device|Firmware|Module version
 |--|--|--|
 |SIM 2x00|V1.5.0|V0.1.0|
+|SIM 2x00|V1.7.0|V1.0.0|
 
 This module is part of the SICK AppSpace Coding Starter Kit developing approach.  
 It is programmed in an object-oriented way. Some of the modules use kind of "classes" in Lua to make it possible to reuse code / classes in other projects.  

--- a/docu/CSK_Module_Fieldbus.html
+++ b/docu/CSK_Module_Fieldbus.html
@@ -619,7 +619,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
 <span id="revnumber">version 1.0.0,</span>
-<span id="revdate">2024-03-22</span>
+<span id="revdate">2024-11-12</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -805,7 +805,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-03-22</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-11-12</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Author</p></th>
@@ -1479,10 +1479,38 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
+<h6 id="_parameters">Parameters</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">wait</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">?</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Set to TRUE if module should wait 1 second before trying to register to events.<br>
+Should be used e.g. if other modules first need to provide dynamically created events which are used.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
 <h6 id="_sample_auto_generated_14">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua">CSK_Fieldbus.loadParameters()</code></pre>
+<pre class="CodeRay highlight"><code data-lang="lua">CSK_Fieldbus.loadParameters(wait)</code></pre>
 </div>
 </div>
 </div>
@@ -1496,10 +1524,37 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
+<h6 id="_return_values">Return values</h6>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Multiplicity</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">success</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BOOL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">TRUE if communication is opened successfully otherwise FALSE</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect5">
 <h6 id="_sample_auto_generated_15">Sample (auto-generated)</h6>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="lua">CSK_Fieldbus.openCommunication()</code></pre>
+<pre class="CodeRay highlight"><code data-lang="lua">success = CSK_Fieldbus.openCommunication()</code></pre>
 </div>
 </div>
 </div>
@@ -1513,7 +1568,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_return_values">Return values</h6>
+<h6 id="_return_values_2">Return values</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1591,7 +1646,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters">Parameters</h6>
+<h6 id="_parameters_2">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1635,7 +1690,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_2">Parameters</h6>
+<h6 id="_parameters_3">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1696,7 +1751,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_3">Parameters</h6>
+<h6 id="_parameters_4">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1741,7 +1796,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_4">Parameters</h6>
+<h6 id="_parameters_5">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1785,7 +1840,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_5">Parameters</h6>
+<h6 id="_parameters_6">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1829,7 +1884,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_6">Parameters</h6>
+<h6 id="_parameters_7">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1873,7 +1928,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_7">Parameters</h6>
+<h6 id="_parameters_8">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1917,7 +1972,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_8">Parameters</h6>
+<h6 id="_parameters_9">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1961,7 +2016,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_9">Parameters</h6>
+<h6 id="_parameters_10">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2005,7 +2060,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_10">Parameters</h6>
+<h6 id="_parameters_11">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2067,7 +2122,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_11">Parameters</h6>
+<h6 id="_parameters_12">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2111,7 +2166,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_12">Parameters</h6>
+<h6 id="_parameters_13">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2155,7 +2210,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_13">Parameters</h6>
+<h6 id="_parameters_14">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2199,7 +2254,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_14">Parameters</h6>
+<h6 id="_parameters_15">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2243,7 +2298,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_15">Parameters</h6>
+<h6 id="_parameters_16">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2287,7 +2342,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_16">Parameters</h6>
+<h6 id="_parameters_17">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2331,7 +2386,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_17">Parameters</h6>
+<h6 id="_parameters_18">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2375,7 +2430,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_18">Parameters</h6>
+<h6 id="_parameters_19">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2420,7 +2475,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_19">Parameters</h6>
+<h6 id="_parameters_20">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2482,7 +2537,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_20">Parameters</h6>
+<h6 id="_parameters_21">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2526,7 +2581,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_21">Parameters</h6>
+<h6 id="_parameters_22">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2570,7 +2625,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_22">Parameters</h6>
+<h6 id="_parameters_23">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2614,7 +2669,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_23">Parameters</h6>
+<h6 id="_parameters_24">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2658,7 +2713,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_24">Parameters</h6>
+<h6 id="_parameters_25">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2702,7 +2757,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_25">Parameters</h6>
+<h6 id="_parameters_26">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2746,7 +2801,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_26">Parameters</h6>
+<h6 id="_parameters_27">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2790,7 +2845,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_27">Parameters</h6>
+<h6 id="_parameters_28">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2834,7 +2889,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_28">Parameters</h6>
+<h6 id="_parameters_29">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2878,7 +2933,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_29">Parameters</h6>
+<h6 id="_parameters_30">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2922,7 +2977,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_30">Parameters</h6>
+<h6 id="_parameters_31">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -2966,7 +3021,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_31">Parameters</h6>
+<h6 id="_parameters_32">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3010,7 +3065,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_32">Parameters</h6>
+<h6 id="_parameters_33">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3055,7 +3110,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_33">Parameters</h6>
+<h6 id="_parameters_34">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3095,11 +3150,11 @@ The received data values will be provided via dynamically created events (see 'C
 <div class="sect5">
 <h6 id="_short_description_56">Short description</h6>
 <div class="paragraph">
-<p>Function to set specific bit of bitmask.</p>
+<p>Function to set specific bit of bitmask (bit range from 0-15).</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_34">Parameters</h6>
+<h6 id="_parameters_35">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3139,11 +3194,11 @@ The received data values will be provided via dynamically created events (see 'C
 <div class="sect5">
 <h6 id="_short_description_57">Short description</h6>
 <div class="paragraph">
-<p>Function to set specific ControlBitIn.</p>
+<p>Function to set specific ControlBitIn (bit range from 0-15).</p>
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_35">Parameters</h6>
+<h6 id="_parameters_36">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3187,7 +3242,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_36">Parameters</h6>
+<h6 id="_parameters_37">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -3231,7 +3286,7 @@ The received data values will be provided via dynamically created events (see 'C
 </div>
 </div>
 <div class="sect5">
-<h6 id="_parameters_37">Parameters</h6>
+<h6 id="_parameters_38">Parameters</h6>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -6488,6 +6543,11 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <td class="tableblock halign-left valign-top"><p class="tableblock">S_LONG</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Signed long (4 bytes)</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><div class="literal"><pre>CHAR</pre></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">CHAR</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 ASCII sign (1 byte)</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -6568,7 +6628,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 <div id="footer">
 <div id="footer-text">
 Version 1.0.0<br>
-Last updated 2024-03-22 14:08:45 +0100
+Last updated 2024-11-12 13:42:34 +0100
 </div>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
# Version x.x.x

## New features
none 

## Improvements

### served function OpenCommunication gives a return value (bool) to indicate if communication is open or not. 
###  on UI the MAC-Adress 'INTERFACE' is shown, so it is comparable to the one seen from PLC-side

## Bugfix

none

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [ ] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [ ] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [ ] CHANGELOG.md is up to date
